### PR TITLE
fix(rule): jsx-filename-extension

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -118,7 +118,7 @@ module.exports = {
     'react/jsx-equals-spacing': ['error', 'never'],
     'react/jsx-indent': ['error', 2],
     'react/jsx-no-target-blank': 'error',
-    'react/jsx-filename-extension': ['error', { extensions: ['.jsx'] }],
+    'react/jsx-filename-extension': ['error', { extensions: ['.js'] }],
     'react/jsx-no-comment-textnodes': 'error',
     'react/no-render-return-value': 'error',
     'react/require-optimization': ['off', { allowDecorators: [] }],


### PR DESCRIPTION
Changed rule from only allowing jsx in .jsx files to .js.