### PR TITLE
fix(overrides): turn off max-lines-per-function

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ module.exports = {
   overrides: [
     {
       files: ['*.test.js', '*.spec.js', 'setupTest.js'],
-      rules: {}
+      rules: {
+        'max-lines-per-function': 'off'
+      }
     }
   ],
 


### PR DESCRIPTION
turn off max-lines-per-function for testing purposes